### PR TITLE
INFL-13344-bump-chart-version-k8s-collector-stable-version

### DIFF
--- a/charts/chart/Chart.yaml
+++ b/charts/chart/Chart.yaml
@@ -3,5 +3,5 @@ name: firefly-k8s-collector
 home: https://github.com/gofireflyio/k8s-collector
 description: Firefly's Kubernetes Collector
 type: application
-version: 1.5.2
-appVersion: "1.5.2"
+version: 1.5.3
+appVersion: "1.5.3"


### PR DESCRIPTION
Bump the chart version to 1.5.3.

Please do not merge before https://github.com/infralight/k8s-collector/pull/4 is merged.