### PR TITLE
INFL-16024-new-version-1.5.4

### DIFF
--- a/charts/chart/Chart.yaml
+++ b/charts/chart/Chart.yaml
@@ -3,5 +3,5 @@ name: firefly-k8s-collector
 home: https://github.com/gofireflyio/k8s-collector
 description: Firefly's Kubernetes Collector
 type: application
-version: 1.5.3
-appVersion: "1.5.3"
+version: 1.5.4
+appVersion: "1.5.4"

--- a/charts/chart/values.yaml
+++ b/charts/chart/values.yaml
@@ -16,6 +16,8 @@ secretKey: null
 # the existing secret should have accessKey and secretKey keys
 # accessKey and secretKey values are ignored if this is set
 existingFireFlyCredentialsSecret: ""
+# to use an existing secret for the argocd access token, set the name of the secret here;
+# the existing secret should have an IACATHON_ARGOCD_TOKEN key
 existingFireFlyArgocdCredentialsSecret: ""
 # incase the integration does not exist in firefly, the collector will create it
 # if you would like to mark as a production cluster set this to true


### PR DESCRIPTION
Add support for specifying an existing ArgoCD token secret in values.yaml

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps chart/app version to 1.5.4 and documents the ArgoCD token secret value in values.yaml.
> 
> - **Helm chart**:
>   - **Version bump**: `charts/chart/Chart.yaml` updates `version` and `appVersion` from `1.5.3` to `1.5.4`.
>   - **Values docs**: `charts/chart/values.yaml` adds comments clarifying use of `existingFireFlyArgocdCredentialsSecret` (expects `IACATHON_ARGOCD_TOKEN`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 700518f8770b2b5557c9943a725cce7b35a6233d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->