### PR TITLE
feat(helm): add configurable podSecurityContext and securityContext

### DIFF
--- a/charts/chart/templates/cronjob.yaml
+++ b/charts/chart/templates/cronjob.yaml
@@ -15,8 +15,10 @@ spec:
     spec:
       template:
         spec:
+          {{- with .Values.podSecurityContext }}
           securityContext:
-            runAsNonRoot: true
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           serviceAccountName: {{ .Values.serviceAccount.name }}
 {{- if .Values.nodeSelector }}
           nodeSelector:
@@ -30,6 +32,10 @@ spec:
             - name: {{ template "fireFlyCollectorContaierName" . }}
               image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
               imagePullPolicy: {{ .Values.image.pullPolicy }}
+              {{- with .Values.securityContext }}
+              securityContext:
+                {{- toYaml . | nindent 16 }}
+              {{- end }}
               env:
                 - name: INFRALIGHT_ACCESS_KEY
                   valueFrom:
@@ -67,6 +73,10 @@ spec:
             - name: {{ template "fireFlyArgocdContainerName" . }}
               image: "{{ .Values.argocd.image.repository }}:{{ .Values.argocd.image.tag | default .Chart.AppVersion }}"
               imagePullPolicy: {{ .Values.argocd.image.pullPolicy }}
+              {{- with .Values.securityContext }}
+              securityContext:
+                {{- toYaml . | nindent 16 }}
+              {{- end }}
               env:
                 - name: FIREFLY_ACCOUNT_ID
                   value: {{ .Values.argocd.metadata.accountId }}

--- a/charts/chart/values.yaml
+++ b/charts/chart/values.yaml
@@ -100,6 +100,24 @@ removeTypes: [ ]
 # addTypes accepts a list of resource types that should be added to the default
 # list of allowed resources. This is mostly useful for CRDs.
 addTypes: [ ]
+# Pod-level security context applied to the collector pod.
+# Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 65532
+  runAsGroup: 65532
+  seccompProfile:
+    type: RuntimeDefault
+
+# Container-level security context applied to each collector container.
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  seccompProfile:
+    type: RuntimeDefault
+
 tolerations: []
 nodeSelector: {}
 onBoarder:


### PR DESCRIPTION
## Summary

The chart currently hardcodes `securityContext.runAsNonRoot: true` at the pod level with no way to configure additional security settings. This makes it impossible to comply with Kubernetes [Pod Security Standards](https://kubernetes.io/docs/concepts/security/pod-security-standards/) (PSS) at the `restricted` level, which additionally requires:

- `seccompProfile` on the pod
- `allowPrivilegeEscalation: false` on each container
- `capabilities.drop: [ALL]` on each container
- `seccompProfile` on each container

## Changes

- **`values.yaml`**: replace the implicit hardcoded pod security context with configurable `podSecurityContext` and `securityContext` values. Defaults are set to match the actual image runtime identity (`USER 65532:65532`) and satisfy PSS `restricted`:
  - `podSecurityContext.runAsNonRoot: true` / `runAsUser: 65532` / `runAsGroup: 65532` / `seccompProfile.type: RuntimeDefault`
  - `securityContext.allowPrivilegeEscalation: false` / `capabilities.drop: [ALL]` / `seccompProfile.type: RuntimeDefault`

- **`cronjob.yaml`**: replace hardcoded `securityContext` block with `{{- with .Values.podSecurityContext }}` template; add `{{- with .Values.securityContext }}` container-level block to both the main collector container and the optional ArgoCD sidecar container

Both fields use `{{- with }}` so setting them to `{}` or `null` omits the field entirely — **fully backwards-compatible** with existing deployments.

## Test plan

- [ ] `helm template` renders `securityContext` fields correctly with default values
- [ ] `helm template` renders no security context fields when both values are set to `{}`
- [ ] ArgoCD sidecar container also gets security context when `argocd.enabled: true`
- [ ] Pods start successfully on a cluster enforcing PSS `restricted`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes rendered Kubernetes `securityContext` for the CronJob pod/containers, which can affect scheduling/startup if clusters or images rely on previous defaults. Risk is moderate because it’s Helm templating/config-driven but touches runtime security settings.
> 
> **Overview**
> Adds configurable `podSecurityContext` and container-level `securityContext` values to the Helm chart (with PSS-restricted-friendly defaults).
> 
> Updates the `CronJob` template to render pod security context from `Values.podSecurityContext` and apply `Values.securityContext` to both the main collector container and the optional ArgoCD sidecar, omitting these blocks when the values are unset.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a0d2a1badd7c1fcf31bb1c351b4db58c3ca2b2e0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->