### PR TITLE
fix: SHA-pin all 3rd-party GitHub Actions (supply chain hardening)

### DIFF
--- a/.github/workflows/workflow.collector.yml
+++ b/.github/workflows/workflow.collector.yml
@@ -51,7 +51,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Get short commit hash
-        uses: benjlevesque/short-sha@v3.0
+        uses: benjlevesque/short-sha@599815c8ee942a9616c92bcfb4f947a3b670ab0b # v3.0
         id: hash
         with:
           length: 8

--- a/.github/workflows/workflow.helm.yml
+++ b/.github/workflows/workflow.helm.yml
@@ -26,7 +26,7 @@ jobs:
           version: v3.8.1
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.4.0     
+        uses: helm/chart-releaser-action@fc23f249f75decd5edf254c6b4401532cef093c3 # v1.4.0     
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/workflow.offboarder.yaml
+++ b/.github/workflows/workflow.offboarder.yaml
@@ -42,7 +42,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Get current time
-        uses: gerred/actions/current-time@master
+        uses: gerred/actions/current-time@c3950138908da5fe2b904f1dc39535d565f1547f # master
         id: current-time
 
       - name: Build and push image to prod


### PR DESCRIPTION
## Summary
Pin all 3rd-party action references to immutable SHA digests.

## Why
Mutable tags can be force-pushed by attackers to point at malicious commits (as happened with aquasecurity/trivy-action on 2026-03-19). SHA-pinned references are immutable and safe from this class of attack.

No functional changes -- all SHAs resolve to the same versions previously referenced by tag.