### PR TITLE
INFL-18366 ci: migrate to GitHub ARC prod runner

### DIFF
--- a/.github/workflows/workflow.collector.yml
+++ b/.github/workflows/workflow.collector.yml
@@ -34,7 +34,7 @@ on:
         required: true
 jobs:
   build:
-    runs-on: [self-hosted, production]
+    runs-on: gofireflyio-runner-prod-arc-arm
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
⚠️ DO NOT MERGE until the prod ARC pools are live — depends on infralight/argocd#3897 being merged + synced + the scale set showing Online. Merging before then makes CI jobs queue forever.

Migrates `runs-on` from the deprecated Summerwind label set to the GitHub ARC scale-set name `gofireflyio-runner-prod-arc-arm` (ARC scale sets route by name, not labels). Part of INFL-18366.